### PR TITLE
Fix loading order issue

### DIFF
--- a/nikki.el
+++ b/nikki.el
@@ -114,7 +114,9 @@ If the date string are single digits, add a leading zero."
   "Add to the keymap in calendar mode."
   (define-key calendar-mode-map (kbd "C-c C-n") 'nikki-open-by-calendar))
 
-(add-hook 'calendar-load-hook 'nikki-assign-calendar-mode-keymap)
+(eval-after-load 'calendar
+  (lambda ()
+    (nikki-assign-calendar-mode-keymap)))
 
 ;;;###autoload
 (defun nikki-find-diary ()


### PR DESCRIPTION
### 修正内容

`calendar-load-hook` の代わりに `eval-after-load` を使う(`with-eval-after-load`の方がモダンだが minimum support versionが 24.3だったので使えない).

### 理由
 
`calendar-load-hook` は calendar.elのロード時に 1回しか実行されないので本パッケージより先に `calendar.el` をロードされていると設定した関数が実行されない. それを回避するために `eval-after-load` を使う. また `calendar-load-hook` は 26.1から obsoleteで利用が推奨されないということもある.

### 再現方法

- `emacs -Q` で起動し, 本パッケージをロード前に `M-x calendar` を実行. その後本パッケージをロードし, `C-c C-n` をしてもコマンドがアサインされない.

本パッチを適用した盤だと上述の手順でも `C-c C-n` にキーがアサインされている.