### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/nikki.el
+++ b/nikki.el
@@ -34,6 +34,7 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'calendar)
 
 (defgroup nikki nil
   "nikki configuration."
@@ -94,7 +95,7 @@ If the date string are single digits, add a leading zero."
    path-list))
   
 ;;;###autoload
-(defun nikki-open-by-calendar (&optional date event)
+(defun nikki-open-by-calendar (&optional _date event)
   "Get and execute a specific date in calendar mode."
   (interactive (list nil last-nonmenu-event))
   (let* ((date (calendar-cursor-to-date t event))


### PR DESCRIPTION
```
nikki.el:97:1:Warning: Unused lexical argument ‘date’

In nikki-assign-calendar-mode-keymap:
nikki.el:115:15:Warning: reference to free variable ‘calendar-mode-map’

In end of data:
nikki.el:152:1:Warning: the function ‘calendar-cursor-to-date’ is not known to
    be defined.
```